### PR TITLE
Fix deletion of backing file when any file referencing it is deleted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ java {
     }
 }
 
+build.dependsOn(spotlessApply)
+
 spotless {
     format 'misc', {
         target '*.gradle', '*.md', '.gitignore'

--- a/src/main/java/engineering/everest/starterkit/filestorage/FileService.java
+++ b/src/main/java/engineering/everest/starterkit/filestorage/FileService.java
@@ -196,6 +196,6 @@ public class FileService {
      * @param batchSize is the number of files to delete
      */
     public void deleteEphemeralFileBatch(int batchSize) {
-        ephemeralDeduplicatingFileStore.deleteFileBatch(batchSize);
+        ephemeralDeduplicatingFileStore.deleteBatchOfFilesMarkedForDeletion(batchSize);
     }
 }

--- a/src/main/java/engineering/everest/starterkit/filestorage/persistence/FileMappingRepository.java
+++ b/src/main/java/engineering/everest/starterkit/filestorage/persistence/FileMappingRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 @Repository
@@ -16,5 +15,5 @@ public interface FileMappingRepository extends JpaRepository<PersistableFileMapp
 
     List<PersistableFileMapping> findByFileStoreType(FileStoreType fileStoreType);
 
-    void deleteAllByBackingStorageFileIdIn(Set<String> backingStorageFileIds);
+    List<PersistableFileMapping> findByBackingStorageFileId(String backingStorageFileId);
 }

--- a/src/test/java/engineering/everest/starterkit/filestorage/FileServiceTest.java
+++ b/src/test/java/engineering/everest/starterkit/filestorage/FileServiceTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
 class FileServiceTest {
 
     private static final String ORIGINAL_FILENAME = "original-filename";
-
     private static final int BATCH_SIZE = 50;
 
     private FileService fileService;
@@ -217,6 +216,6 @@ class FileServiceTest {
     void deleteFileBatch_WillDelegateToEphemeralFileStore() {
         fileService.deleteEphemeralFileBatch(BATCH_SIZE);
 
-        verify(ephemeralFileStore).deleteFileBatch(BATCH_SIZE);
+        verify(ephemeralFileStore).deleteBatchOfFilesMarkedForDeletion(BATCH_SIZE);
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes a severe defect that causes deduplicated backing files to be deleted whenever any file referencing it is deleted.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] My local build passed (You ran `./gradlew clean build` without failures)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have assigned a label to the PR 

